### PR TITLE
Release common-protos-java v1.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ If you are using Maven, add this to your pom.xml file
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-common-protos</artifactId>
-        <version>1.14.0</version>
+        <version>1.15.0</version>
        </dependency>
 
        <dependency>
          <groupId>com.google.api.grpc</groupId>
          <artifactId>grpc-google-common-protos</artifactId>
-         <version>1.14.0</version>
+         <version>1.15.0</version>
        </dependency>
         ...
     </dependencies>
@@ -36,13 +36,13 @@ If you are using Maven, add this to your pom.xml file
 [//]: # ({x-version-update-start:common-protos-java:released})
 If you are using Gradle, add this to your dependencies
 ```Groovy
-compile 'com.google.api.grpc:proto-google-common-protos:1.14.0'
-compile 'com.google.api.grpc:grpc-google-common-protos:1.14.0'
+compile 'com.google.api.grpc:proto-google-common-protos:1.15.0'
+compile 'com.google.api.grpc:grpc-google-common-protos:1.15.0'
 ```
 If you are using SBT, add this to your dependencies
 ```Scala
-libraryDependencies += "com.google.api.grpc" % "proto-google-common-protos" % "1.14.0"
-libraryDependencies += "com.google.api.grpc" % "grpc-google-common-protos" % "1.14.0"
+libraryDependencies += "com.google.api.grpc" % "proto-google-common-protos" % "1.15.0"
+libraryDependencies += "com.google.api.grpc" % "grpc-google-common-protos" % "1.15.0"
 ```
 [//]: # ({x-version-update-end})
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 apply plugin: 'java'
 apply plugin: 'io.codearte.nexus-staging'
 
-project.version = "1.14.1-SNAPSHOT" // {x-version-update:common-protos-java:current}
+project.version = "1.15.0" // {x-version-update:common-protos-java:current}
 
 if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')) {
   // Nexus staging plugin only works at root project level

--- a/grpc-google-common-protos/build.gradle
+++ b/grpc-google-common-protos/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'java'
 
 description = 'GRPC library for grpc-google-common-protos'
 group = 'com.google.api.grpc'
-version = '1.14.1-SNAPSHOT' // {x-version-update:common-protos-java:current}
+version = '1.15.0' // {x-version-update:common-protos-java:current}
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 

--- a/proto-google-common-protos/build.gradle
+++ b/proto-google-common-protos/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'java'
 
 description = 'PROTO library for proto-google-common-protos'
 group = 'com.google.api.grpc'
-version = '1.14.1-SNAPSHOT' // {x-version-update:common-protos-java:current}
+version = '1.15.0' // {x-version-update:common-protos-java:current}
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 

--- a/versions.txt
+++ b/versions.txt
@@ -1,4 +1,4 @@
 # Format:
 # module:released-version:current-version
 
-common-protos-java:1.14.0:1.14.1-SNAPSHOT
+common-protos-java:1.15.0:1.15.0


### PR DESCRIPTION
This pull request was generated using releasetool.

03-20-2019 11:22 PDT

- Refresh protos ([#4](https://github.com/googleapis/common-protos-java/pull/4))
